### PR TITLE
Add gomponents-lucide to gomponents+

### DIFF
--- a/docs/plus/index.html
+++ b/docs/plus/index.html
@@ -44,7 +44,7 @@ func Navbar() g.Node {
 </code></pre></div></div><div><h2 class="inline-flex items-center" id="lucideicons">Lucide Icons<a href="#lucideicons"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" class="ml-2 h-5 w-5 lg:h-6 lg:w-6 xl:h-7 xl:w-7"><path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd"/></svg></a></h2><div><p><a href="https://lucide.dev/">Lucide Icons</a> are a collection of many beautiful & consistent icons made by the community. You can easily use them with gomponents, check out <a href="https://github.com/eduardolat/gomponents-lucide">the gomponents-lucide library on Github</a>.</p><h3>Example</h3><pre><code class="language-go">package main
 
 import (
-	lucide &#34;github.com/eduardolat/gomponents-lucide&#34;
+	&#34;github.com/eduardolat/gomponents-lucide&#34;
 	&#34;github.com/maragudk/gomponents&#34;
 	&#34;github.com/maragudk/gomponents/html&#34;
 )

--- a/docs/plus/index.html
+++ b/docs/plus/index.html
@@ -41,6 +41,27 @@ func Navbar() g.Node {
 		A(Href(&#34;/about&#34;), g.Text(&#34;About&#34;)),
 	)
 }
+</code></pre></div></div><div><h2 class="inline-flex items-center" id="lucideicons">Lucide Icons<a href="#lucideicons"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" class="ml-2 h-5 w-5 lg:h-6 lg:w-6 xl:h-7 xl:w-7"><path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd"/></svg></a></h2><div><p><a href="https://lucide.dev/">Lucide Icons</a> are a collection of many beautiful & consistent icons made by the community. You can easily use them with gomponents, check out <a href="https://github.com/eduardolat/gomponents-lucide">the gomponents-lucide library on Github</a>.</p><h3>Example</h3><pre><code class="language-go">package main
+
+import (
+	lucide &#34;github.com/eduardolat/gomponents-lucide&#34;
+	&#34;github.com/maragudk/gomponents&#34;
+	&#34;github.com/maragudk/gomponents/html&#34;
+)
+
+func myPage() gomponents.Node {
+	return html.Div(
+		lucide.Star(),
+		lucide.Languages(),
+		lucide.Usb(),
+		//...
+		lucide.Cherry(
+			// You can add any attributes you want
+			// to customize the SVG
+			html.Class(&#34;w-6 h-6 text-blue-500&#34;),
+		),
+	)
+}
 </code></pre></div></div><div><h2 class="inline-flex items-center" id="heroicons">Heroicons<a href="#heroicons"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" class="ml-2 h-5 w-5 lg:h-6 lg:w-6 xl:h-7 xl:w-7"><path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd"/></svg></a></h2><div><p><a href="https://heroicons.com">Heroicons</a> are a collection of handcrafted SVG icons, by the makers of TailwindCSS. They work great together with gomponents! Check out <a href="https://github.com/maragudk/gomponents-heroicons">the gomponents-heroicons library on Github</a>.</p><h3>Example</h3><pre><code class="language-go">package icons
 
 import (

--- a/examples/lucideicons/lucideicons.go
+++ b/examples/lucideicons/lucideicons.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	lucide "github.com/eduardolat/gomponents-lucide"
+	"github.com/eduardolat/gomponents-lucide"
 	"github.com/maragudk/gomponents"
 	"github.com/maragudk/gomponents/html"
 )

--- a/examples/lucideicons/lucideicons.go
+++ b/examples/lucideicons/lucideicons.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	lucide "github.com/eduardolat/gomponents-lucide"
+	"github.com/maragudk/gomponents"
+	"github.com/maragudk/gomponents/html"
+)
+
+func myPage() gomponents.Node {
+	return html.Div(
+		lucide.Star(),
+		lucide.Languages(),
+		lucide.Usb(),
+		//...
+		lucide.Cherry(
+			// You can add any attributes you want
+			// to customize the SVG
+			html.Class("w-6 h-6 text-blue-500"),
+		),
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -13,3 +13,5 @@ require (
 	github.com/delaneyj/gomponents-iconify v0.0.0-20230611230628-e1005a1b979f
 	github.com/willoma/bulma-gomponents v0.2.0
 )
+
+require github.com/eduardolat/gomponents-lucide v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/delaneyj/gomponents-iconify v0.0.0-20230611230628-e1005a1b979f h1:v58hcXmvUIf5B0rYIYqBLdRzR3WNTODvz4fM2vsH9+I=
 github.com/delaneyj/gomponents-iconify v0.0.0-20230611230628-e1005a1b979f/go.mod h1:ZjIP4npWKmVuJbvSjBTpzSl1QMimELl77gP/leg1bnI=
+github.com/eduardolat/gomponents-lucide v1.0.0 h1:Hy0oQEEp7q4zQXUPyeJTXHHpkoeJTYlvpM8RAXhK7ec=
+github.com/eduardolat/gomponents-lucide v1.0.0/go.mod h1:C0Yx64QM2RXIal8pl/HdWU0xac0uek+IQI2eZAaeAwk=
 github.com/maragudk/gomponents v0.20.0/go.mod h1:nHkNnZL6ODgMBeJhrZjkMHVvNdoYsfmpKB2/hjdQ0Hg=
 github.com/maragudk/gomponents v0.20.2 h1:39FhnBNNCJzqNcD9Hmvp/5xj0otweFoyvVgFG6kXoy0=
 github.com/maragudk/gomponents v0.20.2/go.mod h1:nHkNnZL6ODgMBeJhrZjkMHVvNdoYsfmpKB2/hjdQ0Hg=

--- a/plus.go
+++ b/plus.go
@@ -17,6 +17,9 @@ var bulma string
 //go:embed examples/heroicons/heroicons.go
 var heroicons string
 
+//go:embed examples/lucideicons/lucideicons.go
+var lucideicons string
+
 //go:embed examples/htmx/htmx.go
 var htmx string
 
@@ -51,6 +54,13 @@ func PlusPage() g.Node {
 				P(g.Raw(`<a href="https://htmx.org">HTMX</a> is a tiny Javascript library to give access to AJAX, websockets, and more, using HTML attributes. This fits perfectly with gomponents when you need that extra bit of client-side interactivity. Check out <a href="https://github.com/maragudk/gomponents-htmx">the gomponents-htmx library on Github</a>.`)),
 				H3(g.Text(`Example`)),
 				CodeBlock(htmx),
+			),
+		},
+		{
+			title: `Lucide Icons`, id: `lucideicons`, body: Div(
+				P(g.Raw(`<a href="https://lucide.dev/">Lucide Icons</a> are a collection of many beautiful & consistent icons made by the community. You can easily use them with gomponents, check out <a href="https://github.com/eduardolat/gomponents-lucide">the gomponents-lucide library on Github</a>.`)),
+				H3(g.Text(`Example`)),
+				CodeBlock(lucideicons),
 			),
 		},
 		{


### PR DESCRIPTION
I recently created a module that includes more than 1400 icons for gomponents and it is very easy to use and I would like to share it with others using gomponents

https://lucide.dev/icons/