### PR TITLE
Corrected port for example in documentation

### DIFF
--- a/index.go
+++ b/index.go
@@ -84,7 +84,7 @@ func IndexPage() g.Node {
 			H3(g.Text("A sample app")),
 			P(
 				g.Text("Sometimes there's nothing like seeing it in action. Try running this complete program and going to "),
-				A(Href("http://localhost:8080"), g.Text("localhost:8080")),
+				A(Href("http://localhost:8081"), g.Text("localhost:8081")),
 				g.Text(" ."),
 			),
 			CodeBlock(simpleExample),


### PR DESCRIPTION
When I tried the example I noticed it uses port `8081` but the doc said to connect to `8080`. :)