### PR TITLE
Fix navbar5/navbar.go example Raw html

### DIFF
--- a/examples/navbar5/navbar.go
+++ b/examples/navbar5/navbar.go
@@ -13,7 +13,7 @@ type NavLink struct {
 
 func Navbar(loggedIn bool, links []NavLink, currentPath string) Node {
 	return Nav(Class("navbar"),
-		Raw(`<span class="logo"><img src="logo.png></span>"`),
+		Raw(`<span class="logo"><img src="logo.png"></span>`),
 
 		Ol(
 			Map(links, func(l NavLink) Node {


### PR DESCRIPTION
I assume the quote is misplaced? Or was this meant to be an example of the freedom with Raw html?