### PR TITLE
Pin Tailwind v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ serve:
 	go run ./cmd/server
 
 tailwindcss:
-	curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-macos-arm64
+	curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/download/v3.4.15/tailwindcss-macos-arm64
 	mv tailwindcss-macos-arm64 tailwindcss
 	chmod +x tailwindcss
 	mkdir -p node_modules/tailwindcss/lib && ln -s tailwindcss node_modules/tailwindcss/lib/cli.js
-	echo '{"devDependencies": {"tailwindcss": "latest"}}' >package.json
+	echo '{"devDependencies": {"tailwindcss": "3.4.15"}}' >package.json
 
 .PHONY: watch-css
 watch-css: tailwindcss

--- a/package.json
+++ b/package.json
@@ -1,1 +1,1 @@
-{"devDependencies": {"tailwindcss": "latest"}}
+{"devDependencies": {"tailwindcss": "3.4.15"}}


### PR DESCRIPTION
Tailwind v4 released a week or two ago and it broke the site CSS when we rolled out the converter list. At least for now, the quickest fix is to just point to a v3 release of the Tailwind CLI.